### PR TITLE
Fix top menu layout on narrow screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
   <body class="bg-gray-100">
     <header class="absolute inset-x-0 top-0 z-50">
       <nav
-        class="flex items-center justify-between p-6 px-8"
+        class="flex items-center justify-between flex-wrap xs:flex-nowrap p-6 px-8 whitespace-nowrap"
         aria-label="Global">
-        <div class="flex flex-1">
+        <div class="flex grow shrink-0 basis-1/3">
           <a href="#" class="-m-1.5 p-1.5">
             <span class="sr-only">Olympia Gym</span>
             <img
@@ -30,13 +30,13 @@
               alt="" />
           </a>
         </div>
-        <div class="flex gap-x-12">
+        <div class="flex gap-x-12 max-xs:order-last max-xs:basis-full max-xs:justify-around">
           <a href="#clenstvi" class="text-sm font-semibold leading-6 text-white"
             >Členství</a
           >
           <a href="#faq" class="text-sm font-semibold leading-6 text-white">FAQ</a>
         </div>
-        <div class="flex justify-end flex-1">
+        <div class="flex justify-end grow shrink-0 basis-1/3">
           <a href="https://billing.stripe.com/p/login/test_7sI4jJdxD6Px6e4bII" class="text-sm font-semibold leading-6 text-white"
             >Správa členství<span aria-hidden="true">&rarr;</span></a
           >

--- a/static/output.css
+++ b/static/output.css
@@ -548,6 +548,12 @@ video {
   width: 100%;
 }
 
+@media (min-width: 550px) {
+  .container {
+    max-width: 550px;
+  }
+}
+
 @media (min-width: 640px) {
   .container {
     max-width: 640px;
@@ -934,10 +940,6 @@ video {
   max-width: 28rem;
 }
 
-.flex-1 {
-  flex: 1 1 0%;
-}
-
 .flex-none {
   flex: none;
 }
@@ -950,12 +952,20 @@ video {
   flex-shrink: 1;
 }
 
+.shrink-0 {
+  flex-shrink: 0;
+}
+
 .flex-grow {
   flex-grow: 1;
 }
 
 .grow {
   flex-grow: 1;
+}
+
+.basis-1\/3 {
+  flex-basis: 33.333333%;
 }
 
 .table-auto {
@@ -2795,6 +2805,12 @@ video {
     width: 100%;
   }
 
+  @media (min-width: 550px) {
+    .sm\:container {
+      max-width: 550px;
+    }
+  }
+
   @media (min-width: 640px) {
     .sm\:container {
       max-width: 640px;
@@ -2893,6 +2909,20 @@ video {
   outline-color: #4f46e5;
 }
 
+@media not all and (min-width: 550px) {
+  .max-xs\:order-last {
+    order: 9999;
+  }
+
+  .max-xs\:basis-full {
+    flex-basis: 100%;
+  }
+
+  .max-xs\:justify-around {
+    justify-content: space-around;
+  }
+}
+
 @media (min-width: 640px) {
   .sm\:mt-20 {
     margin-top: 5rem;
@@ -2904,6 +2934,10 @@ video {
 
   .sm\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sm\:flex-nowrap {
+    flex-wrap: nowrap;
   }
 
   .sm\:gap-x-6 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
         "hero-bg": "url('/static/jelmer-assink-gzeTjGu3b_k-unsplash.jpg')",
       }),
     },
+    screens: {
+      xs: "550px",
+      ...defaultTheme.screens,
+    },
   },
   variants: {},
   plugins: [],


### PR DESCRIPTION
Split the menu into two rows on narrow screens by shifting the centered options onto the second row.